### PR TITLE
docs: add WebView Client ID Sync optional section to AGENTS.md

### DIFF
--- a/AGENTS-snippets.md
+++ b/AGENTS-snippets.md
@@ -633,3 +633,55 @@ try {
   console.error(error);
 }
 ```
+
+---
+
+## WebView Client ID Sync (Optional)
+
+Pass `clidSyncConfig` to `createTracker` only when the developer explicitly requests linking native and in-app WebView sessions. Omit this config entirely if not requested.
+
+**`src/conviva.ts` (TypeScript):**
+```ts
+import { createTracker, ReactNativeTracker } from '@convivainc/conviva-react-native-appanalytics';
+
+let tracker: ReactNativeTracker | undefined;
+try {
+  tracker = createTracker('YOUR_CUSTOMER_KEY', 'YOUR_APP_NAME', {
+    clidSyncConfig: {
+      webViewCookie: {
+        domains: ['.example.com', '.partner.com'], // leading-dot covers all subdomains
+      },
+    },
+  });
+  if (!tracker) {
+    console.error('Tracker initialization returned null');
+  }
+} catch (error) {
+  console.error(error);
+}
+export { tracker };
+```
+
+**`src/conviva.js` (JavaScript):**
+```js
+import { createTracker } from '@convivainc/conviva-react-native-appanalytics';
+
+let tracker;
+try {
+  tracker = createTracker('YOUR_CUSTOMER_KEY', 'YOUR_APP_NAME', {
+    clidSyncConfig: {
+      webViewCookie: {
+        domains: ['.example.com', '.partner.com'], // leading-dot covers all subdomains
+      },
+    },
+  });
+  if (!tracker) {
+    console.error('Tracker initialization returned null');
+  }
+} catch (error) {
+  console.error(error);
+}
+export { tracker };
+```
+
+> Replace `.example.com` and `.partner.com` with the actual domains hosting the in-app WebView content. Use the same domain list in Conviva remote config to ensure uninterrupted client ID sharing from the very first WebView load.

--- a/AGENTS-snippets.md
+++ b/AGENTS-snippets.md
@@ -617,6 +617,10 @@ try {
 
 ## Client ID (Optional)
 
+> **Prefer automatic sync for `react-native-webview`.** If the app uses `react-native-webview` v11+, use `clidSyncConfig` in `createTracker` (see **§ WebView Client ID Sync** below) — it handles cookie seeding and JS bridge automatically with no manual code.
+>
+> Use `getClientId()` / `setClientId()` only for surfaces automatic sync cannot reach, or when managing the client ID for your own backend purposes.
+
 ```js
 import { getClientId, setClientId } from '@convivainc/conviva-react-native-appanalytics';
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -492,9 +492,9 @@ Check `package.json` for `react-native-webview` in `dependencies` or `devDepende
 
 **Step 4 — Add `clidSyncConfig` to `createTracker`:**
 
-Prefix each domain with a leading dot for subdomain coverage. Edit `src/conviva.ts` (or `src/conviva.js`) to pass `clidSyncConfig` as the third argument to `createTracker`. See **AGENTS-snippets.md § WebView Client ID Sync** for the exact snippet.
+Prefix each domain with a leading dot for subdomain coverage. Edit `src/conviva.ts` (or `src/conviva.js`) to pass `clidSyncConfig` as the third argument to `createTracker`. See **DEVELOPER_GUIDE.md § WebView Client ID Sync** for the exact snippet.
 
-> **Note:** The `enabled` flags inside `webViewCookie` and `webViewBridge` are remote-config controlled — local values are ignored. Only `domains` is respected from app code. Match the domain list here with the remote config list to avoid gaps on first launch.
+> **Note:** The `enabled` flags inside `webViewCookie` and `webViewBridge` are remote-config controlled — local values are ignored. Only `clidSyncConfig.webViewCookie.domains` is respected from app code and there is no `clidSyncConfig.webViewBridge.domains` field. Match the domain list here with the remote config list to avoid gaps on first launch.
 
 Record in Section 18: "WebView CLID sync: configured with domains [list domains]."
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Single source of truth. Governs: Cursor, Claude Code, Codex, ChatGPT, Gemini CLI
 1. State: "I have read AGENTS.md and will follow its contract."
 2. Ask developer for all inputs in Section 3 before writing any code.
 3. Seed task list from Section 17 before writing any code.
-4. Execute Sections 4-16 in order. Every Section 17 row must appear in your response.
+4. Execute Sections 4-17 in order. Every Section 18 row must appear in your response.
 5. If you cannot proceed without violating a rule, stop and ask.
 
 ---
@@ -454,7 +454,25 @@ Use `tracker.trackPageView({pageUrl, pageTitle?, referrer?})` to track in-app pa
 
 ---
 
-## 16. Build and Validation
+## 16. WebView Client ID Sync (Optional)
+
+Implement **only when the developer explicitly requests** linking native and in-app WebView sessions under the same user identity. Skip this section entirely if the developer has not asked for it.
+
+**How it works:** The SDK automatically shares the native client ID with in-app WebViews via two mechanisms:
+- **Cookie (primary):** Seeds a `Conviva_sdkConfig` cookie into the WebView for each configured domain. The Conviva Web SDK reads it on page load.
+- **JS bridge (fallback):** When the cookie is unavailable, the Web SDK calls the native bridge to retrieve the client ID. The bridge interface differs by platform: **Android** uses `window.__ConvivaNativeWebInterface.getClientId()`; **iOS** uses `window.webkit.messageHandlers.__ConvivaiOSGetClientIdInterface`. Requires **Conviva Web SDK ≥ 2.2.0** and JavaScript enabled in the WebView.
+
+**No code changes are required** if domains are managed via Conviva remote config — contact Conviva support to configure domains remotely.
+
+**To seed cookies immediately at launch** (before remote config loads), pass `clidSyncConfig` to `createTracker` in `src/conviva.ts` / `src/conviva.js`. See **AGENTS-snippets.md § WebView Client ID Sync** for the code example.
+
+> **Domain format:** Use leading-dot domains (`.example.com`) to cover all subdomains. Match the `domains` list in app code with the remote config list to avoid gaps on first launch.
+>
+> **Note:** The `enabled` flags inside `webViewCookie` and `webViewBridge` are remote-config controlled — local values are ignored. Only `domains` is respected from app code.
+
+---
+
+## 17. Build and Validation
 
 **Build verification:** Ask developer to run both Android and iOS debug builds. Share any error output and fix using only Section 13 allowed symbols.
 
@@ -467,7 +485,7 @@ If Metro bundler errors occur, read `AGENTS-troubleshooting.md`.
 
 ---
 
-## 17. Mandatory Checklist
+## 18. Mandatory Checklist
 
 Seed your task list from this table before writing any code. Every row must appear in your final response.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -456,19 +456,55 @@ Use `tracker.trackPageView({pageUrl, pageTitle?, referrer?})` to track in-app pa
 
 ## 16. WebView Client ID Sync (Optional)
 
-Implement **only when the developer explicitly requests** linking native and in-app WebView sessions under the same user identity. Skip this section entirely if the developer has not asked for it.
+**Step 1 — Detect WebView usage (from Section 3a scan results, no re-read needed):**
 
-**How it works:** The SDK automatically shares the native client ID with in-app WebViews via two mechanisms:
-- **Cookie (primary):** Seeds a `Conviva_sdkConfig` cookie into the WebView for each configured domain. The Conviva Web SDK reads it on page load.
-- **JS bridge (fallback):** When the cookie is unavailable, the Web SDK calls the native bridge to retrieve the client ID. The bridge interface differs by platform: **Android** uses `window.__ConvivaNativeWebInterface.getClientId()`; **iOS** uses `window.webkit.messageHandlers.__ConvivaiOSGetClientIdInterface`. Requires **Conviva Web SDK ≥ 2.2.0** and JavaScript enabled in the WebView.
+Check `package.json` for `react-native-webview` in `dependencies` or `devDependencies`.
 
-**No code changes are required** if domains are managed via Conviva remote config — contact Conviva support to configure domains remotely.
+| Result | Action |
+|---|---|
+| Not found | Skip this section. Record in Section 18: "WebView CLID sync: skipped — `react-native-webview` not found." |
+| Found at version < 11 | Skip this section. Record in Section 18: "WebView CLID sync: skipped — `react-native-webview` v11+ required (found vX)." |
+| Found at version >= 11 | Continue to Step 2. |
 
-**To seed cookies immediately at launch** (before remote config loads), pass `clidSyncConfig` to `createTracker` in `src/conviva.ts` / `src/conviva.js`. See **AGENTS-snippets.md § WebView Client ID Sync** for the code example.
+---
 
-> **Domain format:** Use leading-dot domains (`.example.com`) to cover all subdomains. Match the `domains` list in app code with the remote config list to avoid gaps on first launch.
+**Step 2 — Ask the developer:**
+
+> "Your app uses `react-native-webview`. Do you want Conviva to track native and in-app WebView sessions as a single user identity — so a user's journey is continuous across native screens and web content?"
 >
-> **Note:** The `enabled` flags inside `webViewCookie` and `webViewBridge` are remote-config controlled — local values are ignored. Only `domains` is respected from app code.
+> - **Yes** → continue to Step 3.
+> - **No / Skip** → record in Section 18: "WebView CLID sync: skipped by developer." Move to Section 17.
+
+---
+
+**Step 3 — Ask for domains:**
+
+> "What domains does your WebView load? (e.g. `app.example.com`, `checkout.partner.com`)
+>
+> Providing domains seeds cookies immediately at launch, before remote config loads. You can skip this if you prefer to manage all domains via Conviva remote config — contact Conviva support in that case."
+
+| Response | Action |
+|---|---|
+| No domains provided / skip | No code changes. Record in Section 18: "WebView CLID sync: enabled — domains via remote config only." Move to Section 17. |
+| Domains provided | Continue to Step 4. |
+
+---
+
+**Step 4 — Add `clidSyncConfig` to `createTracker`:**
+
+Prefix each domain with a leading dot for subdomain coverage. Edit `src/conviva.ts` (or `src/conviva.js`) to pass `clidSyncConfig` as the third argument to `createTracker`. See **AGENTS-snippets.md § WebView Client ID Sync** for the exact snippet.
+
+> **Note:** The `enabled` flags inside `webViewCookie` and `webViewBridge` are remote-config controlled — local values are ignored. Only `domains` is respected from app code. Match the domain list here with the remote config list to avoid gaps on first launch.
+
+Record in Section 18: "WebView CLID sync: configured with domains [list domains]."
+
+---
+
+**Step 5 — Non-`react-native-webview` surfaces:**
+
+If the developer mentions opening web content outside `react-native-webview`, automatic sync does not cover these surfaces. Inform the developer:
+
+> "Automatic CLID sync only works for `react-native-webview`. For other surfaces, use `getClientId()` and `setClientId()` to manage the client ID manually. See **AGENTS-snippets.md § Client ID** for the API."
 
 ---
 
@@ -503,6 +539,7 @@ Seed your task list from this table before writing any code. Every row must appe
 | User ID setup | Login, registration, and logout implementation; or stop instructions if PII-only |
 | Custom events and tags | One code snippet each (if requested) |
 | PageView tracking | Implemented (if requested) or skipped |
+| WebView CLID sync | One of: (a) skipped — `react-native-webview` not found; (b) skipped — version < 11; (c) skipped by developer; (d) enabled — domains via remote config only; (e) configured with domains [list] and `clidSyncConfig` added to `createTracker`; non-`react-native-webview` surfaces noted if raised by developer |
 | AGP compatibility check | Detected AGP version; if >= 9.0, confirm plugin >= 0.3.7; or skipped if no Android setup |
 | Build verification | Outcome for both Android and iOS |
 | Product validation | Ask developer to validate in Pulse App -> Activation Module -> Live Lens |

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -607,12 +607,9 @@ try {
   tracker = createTracker('YOUR_CUSTOMER_KEY', 'YOUR_APP_NAME', {
     clidSyncConfig: {
       webViewCookie: {
-        enabled: true,
         domains: ['.example.com', '.partner.com'], // use leading-dot for subdomain coverage
       },
-      webViewBridge: {
-        enabled: true,
-      },
+      webViewBridge: {},
     },
   });
 } catch (error) {
@@ -629,12 +626,9 @@ try {
   tracker = createTracker('YOUR_CUSTOMER_KEY', 'YOUR_APP_NAME', {
     clidSyncConfig: {
       webViewCookie: {
-        enabled: true,
         domains: ['.example.com', '.partner.com'], // use leading-dot for subdomain coverage
       },
-      webViewBridge: {
-        enabled: true,
-      },
+      webViewBridge: {},
     },
   });
 } catch (error) {
@@ -647,11 +641,6 @@ try {
 | Option | Type | Description |
 |---|---|---|
 | `webViewCookie.domains` | `string[]` | Domains that receive the `Conviva_sdkConfig` cookie. Use leading-dot form (`.example.com`). |
-| `webViewCookie.enabled` | `boolean` | Override for cookie sync enable state (primarily remote-config-controlled). |
-| `webViewBridge.enabled` | `boolean` | Enables `__ConvivaNativeWebInterface` JS bridge in WebViews (primarily remote-config-controlled). |
-
-> The `enabled` flags are primarily controlled by Conviva remote config; app-supplied values serve as a local fallback.
-> CLID sync is not supported on tvOS and is silently ignored on that platform.
 
 
 ### Client ID

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -577,6 +577,83 @@ try {
 
 The web app must use the Conviva WebView tracker to send events.
 
+### WebView Client ID Sync
+
+> Available from React Native SDK [v0.4.0](https://github.com/Conviva/conviva-react-native-appanalytics/releases/tag/v0.4.0). Requires React Native 0.68+ with [`react-native-webview`](https://github.com/react-native-webview/react-native-webview) v11+.
+
+The SDK automatically shares the native client ID with in-app WebViews, linking native and web sessions to the same user. Two mechanisms handle this:
+
+- **Cookie (primary):** Seeds a `Conviva_sdkConfig` cookie into the WebView cookie jar per configured domain.
+- **JS bridge (fallback):** Web SDK reads the native client ID from the injected bridge when the cookie is unavailable.
+
+> JavaScript must be enabled in the WebView for either approach to function.
+
+**Web SDK compatibility:** The cookie path works with any Web SDK version. The JS bridge fallback requires **Web SDK ≥ [2.2.0](https://github.com/Conviva/conviva-js-appanalytics/releases/tag/v2.2.0)**.
+
+#### Integration Options
+
+**Option 1 — Remote config only (no code changes required):** Both cookie seeding and JS bridge are enabled by default. Contact Conviva support to configure domains in remote config for your account.
+
+**Option 2 — Supply fallback domains in app code:**
+
+Pass a `clidSyncConfig` object as the third argument to `createTracker()`. App-config domains take effect immediately on first launch, before the first remote config fetch. Once remote config is fetched, its domain list replaces the app-config list.
+
+**JavaScript:**
+```js
+import { createTracker } from '@convivainc/conviva-react-native-appanalytics';
+
+let tracker;
+try {
+  tracker = createTracker('YOUR_CUSTOMER_KEY', 'YOUR_APP_NAME', {
+    clidSyncConfig: {
+      webViewCookie: {
+        enabled: true,
+        domains: ['.example.com', '.partner.com'], // use leading-dot for subdomain coverage
+      },
+      webViewBridge: {
+        enabled: true,
+      },
+    },
+  });
+} catch (error) {
+  console.error(error);
+}
+```
+
+**TypeScript:**
+```ts
+import { createTracker, ReactNativeTracker } from '@convivainc/conviva-react-native-appanalytics';
+
+let tracker: ReactNativeTracker | undefined;
+try {
+  tracker = createTracker('YOUR_CUSTOMER_KEY', 'YOUR_APP_NAME', {
+    clidSyncConfig: {
+      webViewCookie: {
+        enabled: true,
+        domains: ['.example.com', '.partner.com'], // use leading-dot for subdomain coverage
+      },
+      webViewBridge: {
+        enabled: true,
+      },
+    },
+  });
+} catch (error) {
+  console.error(error);
+}
+```
+
+> Use leading-dot domains (`.example.com`) to cover all subdomains. Domains without a leading dot match only the exact host.
+
+| Option | Type | Description |
+|---|---|---|
+| `webViewCookie.domains` | `string[]` | Domains that receive the `Conviva_sdkConfig` cookie. Use leading-dot form (`.example.com`). |
+| `webViewCookie.enabled` | `boolean` | Override for cookie sync enable state (primarily remote-config-controlled). |
+| `webViewBridge.enabled` | `boolean` | Enables `__ConvivaNativeWebInterface` JS bridge in WebViews (primarily remote-config-controlled). |
+
+> The `enabled` flags are primarily controlled by Conviva remote config; app-supplied values serve as a local fallback.
+> CLID sync is not supported on tvOS and is silently ignored on that platform.
+
+
 ### Client ID
 
 ```js

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -609,7 +609,6 @@ try {
       webViewCookie: {
         domains: ['.example.com', '.partner.com'], // use leading-dot for subdomain coverage
       },
-      webViewBridge: {},
     },
   });
 } catch (error) {
@@ -628,7 +627,6 @@ try {
       webViewCookie: {
         domains: ['.example.com', '.partner.com'], // use leading-dot for subdomain coverage
       },
-      webViewBridge: {},
     },
   });
 } catch (error) {

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -579,9 +579,9 @@ The web app must use the Conviva WebView tracker to send events.
 
 ### WebView Client ID Sync
 
-> Available from React Native SDK [v0.4.0](https://github.com/Conviva/conviva-react-native-appanalytics/releases/tag/v0.4.0). Requires React Native 0.68+ with [`react-native-webview`](https://github.com/react-native-webview/react-native-webview) v11+. JavaScript must be enabled in the WebView for this feature to work.
+> Available from React Native SDK [v0.4.0](https://github.com/Conviva/conviva-react-native-appanalytics/releases/tag/v0.4.0). Requires React Native 0.68+, [`react-native-webview`](https://github.com/react-native-webview/react-native-webview) v11+, and Android plugin [v0.3.9](https://github.com/Conviva/conviva-android-plugin/releases/tag/v0.3.9)+. JavaScript must be enabled in the WebView for this feature to work.
 
-The SDK automatically shares the native client ID with in-app WebViews, linking native and web sessions to the same user. Two mechanisms handle this:
+The SDK automatically shares the native client ID with in-app WebViews, linking native and web sessions to the same user. It uses two mechanisms:
 
 - **Cookie (primary):** Seeds a `Conviva_sdkConfig` cookie into the WebView cookie jar per configured domain.
 - **JS bridge (fallback):** Web SDK reads the native client ID from the injected bridge when the cookie is unavailable.
@@ -594,7 +594,7 @@ The SDK automatically shares the native client ID with in-app WebViews, linking 
 
 **Option 2 — Supply fallback domains in app code:**
 
-Pass a `clidSyncConfig` object as the third argument to `createTracker()`. App-config domains take effect immediately on first launch, before the first remote config fetch. Once remote config is fetched, its domain list replaces the app-config list.
+Pass a `clidSyncConfig` object as the third argument to `createTracker()`. App-config domains take effect immediately before the first remote config fetch; once remote config is received, its domain list replaces the app-config list.
 
 **JavaScript:**
 ```js
@@ -606,7 +606,7 @@ try {
     clidSyncConfig: {
       webViewCookie: {
         domains: ['.example.com', '.partner.com'], // use leading-dot for subdomain coverage
-      },
+      }
     },
   });
 } catch (error) {
@@ -624,7 +624,7 @@ try {
     clidSyncConfig: {
       webViewCookie: {
         domains: ['.example.com', '.partner.com'], // use leading-dot for subdomain coverage
-      },
+      }
     },
   });
 } catch (error) {

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -579,14 +579,12 @@ The web app must use the Conviva WebView tracker to send events.
 
 ### WebView Client ID Sync
 
-> Available from React Native SDK [v0.4.0](https://github.com/Conviva/conviva-react-native-appanalytics/releases/tag/v0.4.0). Requires React Native 0.68+ with [`react-native-webview`](https://github.com/react-native-webview/react-native-webview) v11+.
+> Available from React Native SDK [v0.4.0](https://github.com/Conviva/conviva-react-native-appanalytics/releases/tag/v0.4.0). Requires React Native 0.68+ with [`react-native-webview`](https://github.com/react-native-webview/react-native-webview) v11+. JavaScript must be enabled in the WebView for this feature to work.
 
 The SDK automatically shares the native client ID with in-app WebViews, linking native and web sessions to the same user. Two mechanisms handle this:
 
 - **Cookie (primary):** Seeds a `Conviva_sdkConfig` cookie into the WebView cookie jar per configured domain.
 - **JS bridge (fallback):** Web SDK reads the native client ID from the injected bridge when the cookie is unavailable.
-
-> JavaScript must be enabled in the WebView for either approach to function.
 
 **Web SDK compatibility:** The cookie path works with any Web SDK version. The JS bridge fallback requires **Web SDK ≥ [2.2.0](https://github.com/Conviva/conviva-js-appanalytics/releases/tag/v2.2.0)**.
 


### PR DESCRIPTION
Adds Section 16 (WebView Client ID Sync) to the AI agent contract, explaining the optional feature for linking native and in-app WebView sessions via cookie seeding and JS bridge fallback. Renumbers existing Build/Validation and Mandatory Checklist sections to 17 and 18. Adds matching TypeScript and JavaScript snippets to AGENTS-snippets.md.