### PR TITLE
docs: add 0.5.0 error tracking docs and bump version to 0.5.0

### DIFF
--- a/AGENTS-snippets.md
+++ b/AGENTS-snippets.md
@@ -406,6 +406,158 @@ try {
 
 ---
 
+## Error Tracking (>= 0.5.0)
+
+JS error tracking is **on by default** — uncaught errors and unhandled promise rejections are captured automatically once `createTracker(...)` runs.
+
+Everything below is **optional**; add it only when the developer requests it (see AGENTS.md § 16a Step 1). `trackError` and `errorTracker` are **standalone exports** — import them directly; they do not require the `tracker` instance and need no `if (tracker != null)` guard.
+
+### Disable or configure via `errorTracking`
+
+Pass `errorTracking` as the third argument to `createTracker` in `src/conviva.ts` (or `src/conviva.js`). Pass `false` to disable, or an object to tune capture. Omit it entirely to keep the defaults.
+
+#### Allowed `errorTracking` config keys
+
+When passing the object form, use **only** these keys — do not invent others. All are optional.
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `enabled` | `boolean` | `true` | Master switch for the error tracking module. |
+| `captureGlobalErrors` | `boolean` | `true` | Capture uncaught errors via the global handler. |
+| `captureUnhandledRejections` | `boolean` | `true` | Capture unhandled promise rejections. |
+| `suppressInDev` | `boolean` | `false` | Skip capture while running in `__DEV__`. |
+| `enableRateLimiting` | `boolean` | `true` | Drop events once the per-window limit is exceeded. |
+| `maxEventsPerWindow` | `number` | `20` | Max events captured per rate-limit window. |
+| `rateLimitWindowMs` | `number` | `1000` | Rate-limit window length, in milliseconds. |
+| `disconnectDurationMs` | `number` | `2000` | Cool-down after the limit is hit, in milliseconds. |
+| `promiseRejectionsAsHandled` | `boolean` | `false` | Report unhandled rejections as handled (`warning`) instead of unhandled (`error`). |
+| `bundleId` | `string` | — | JS bundle hash for symbolication of OTA-updated apps. |
+| `beforeCapture` | `(payload) => boolean \| void` | — | Enrich or filter each event; return `false` to drop it. |
+
+> `errorTracking: false` (the boolean form) fully disables the module. The object form keeps tracking on and overrides only the keys you set.
+
+**`src/conviva.ts` (TypeScript) — disable:**
+```ts
+import { createTracker, ReactNativeTracker } from '@convivainc/conviva-react-native-appanalytics';
+
+let tracker: ReactNativeTracker | undefined;
+try {
+  tracker = createTracker('YOUR_CUSTOMER_KEY', 'YOUR_APP_NAME', {
+    errorTracking: false, // fully disable JS error capture
+  });
+  if (!tracker) {
+    console.error('Tracker initialization returned null');
+  }
+} catch (error) {
+  console.error(error);
+}
+export { tracker };
+```
+
+**`src/conviva.js` (JavaScript) — tune capture:**
+```js
+import { createTracker } from '@convivainc/conviva-react-native-appanalytics';
+
+let tracker;
+try {
+  tracker = createTracker('YOUR_CUSTOMER_KEY', 'YOUR_APP_NAME', {
+    errorTracking: {
+      suppressInDev: true,       // skip capture in __DEV__
+      maxEventsPerWindow: 10,    // default 20
+      beforeCapture: (payload) => {
+        // Return false to drop an event; mutate payload to enrich it.
+        if (payload.message.includes('Network request failed')) {
+          return false;
+        }
+      },
+    },
+  });
+  if (!tracker) {
+    console.error('Tracker initialization returned null');
+  }
+} catch (error) {
+  console.error(error);
+}
+export { tracker };
+```
+
+**Merging with an existing third argument** — `createTracker` takes a single config object. If one is already passed (e.g. `clidSyncConfig` from WebView CLID sync), add `errorTracking` to the **same** object; do not add a second argument or replace existing keys:
+```js
+tracker = createTracker('YOUR_CUSTOMER_KEY', 'YOUR_APP_NAME', {
+  clidSyncConfig: {
+    webViewCookie: { domains: ['.example.com'] },
+  },
+  errorTracking: {
+    suppressInDev: true,
+  },
+});
+```
+
+### Capture render-phase errors with `ConvivaErrorBoundary`
+
+Wrap any subtree to capture errors thrown during render and show a fallback UI.
+
+```jsx
+import { ConvivaErrorBoundary } from '@convivainc/conviva-react-native-appanalytics';
+import { View, Text, Button } from 'react-native';
+
+<ConvivaErrorBoundary
+  name="CheckoutScreen"
+  fallback={({ error, reset }) => (
+    <View>
+      <Text>Something went wrong: {String(error && error.message)}</Text>
+      <Button title="Try again" onPress={reset} />
+    </View>
+  )}
+>
+  <CheckoutScreen />
+</ConvivaErrorBoundary>
+```
+
+### Report handled errors with `trackError`
+
+```js
+import { trackError } from '@convivainc/conviva-react-native-appanalytics';
+
+try {
+  await riskyOperation();
+} catch (error) {
+  try {
+    await trackError({
+      message: error.message,
+      errorType: error.name,   // optional
+      stackTrace: error.stack, // optional
+      isFatal: false,          // optional
+      isHandled: true,         // optional
+      attributes: { feature: 'checkout', step: 'payment' }, // optional
+    });
+  } catch (e) {
+    console.error(e);
+  }
+}
+```
+
+> `trackError` is also available on the tracker instance: `tracker.trackError({ message: '...' })`. Only `message` is required.
+
+### Attach custom attributes to every error
+
+```js
+import { errorTracker } from '@convivainc/conviva-react-native-appanalytics';
+
+try {
+  errorTracker.addAttribute('appBuild', '2026.6.1');
+  errorTracker.addAttribute('environment', 'production');
+  // Remove when no longer relevant:
+  errorTracker.removeAttribute('environment');
+} catch (error) {
+  console.error(error);
+}
+```
+
+> `errorTracker` also exposes `setEnabled(boolean)` to toggle capture and `setRateLimitingEnabled(boolean)` to toggle rate limiting at runtime.
+
+---
+
 ## React Navigation Autotracking
 
 ### React Navigation >= 5 (NavigationContainer)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Single source of truth. Governs: Cursor, Claude Code, Codex, ChatGPT, Gemini CLI
 1. State: "I have read AGENTS.md and will follow its contract."
 2. Ask developer for all inputs in Section 3 before writing any code.
 3. Seed task list from Section 17 before writing any code.
-4. Execute Sections 4-17 in order. Every Section 18 row must appear in your response.
+4. Execute Sections 4-17 in order, including lettered subsections in sequence (e.g. 16a comes after 16, before 17). Every Section 18 row must appear in your response.
 5. If you cannot proceed without violating a rule, stop and ask.
 
 ---
@@ -354,7 +354,7 @@ See `AGENTS-snippets.md` for complete, copy-ready snippets.
 - In the root component file (`App.tsx`, `App.js`, or `index.js`), add a side-effect import at the top: `import './conviva'`. Do not call `createTracker` there.
 - In any other file that needs the tracker (e.g. Redux action files, hooks), import the exported instance using the project's path alias if available (e.g. `import { tracker } from '@src/conviva'`), otherwise use a relative path.
 - Before creating `src/conviva.ts`, check whether a path alias for `src/` is configured in `babel.config.js` or `tsconfig.json` (e.g. `@src`). Use that alias in all imports of the tracker across the project.
-- Forbidden: passing a third `controllerConfig` argument unless explicitly instructed by the developer.
+- Forbidden: passing a third `controllerConfig` argument unless explicitly instructed by the developer. A developer request to configure WebView CLID sync (Section 16) or error tracking (Section 16a) **is** such an instruction. When more than one such config is requested, pass a **single** third-argument object and merge all requested keys (e.g. `clidSyncConfig`, `errorTracking`) into it — never pass two third arguments.
 - Forbidden: calling `createTracker` anywhere other than `src/conviva.ts` / `src/conviva.js`.
 - Import: `import { createTracker } from '@convivainc/conviva-react-native-appanalytics';`
 
@@ -432,6 +432,14 @@ See `AGENTS-snippets.md` -> React Navigation Autotracking for complete JS and TS
 | `getWebViewCallback()` | WebView event bridge |
 | `getClientId()` | Get client ID |
 | `setClientId(clientId)` | Set client ID |
+| `createTracker(customerKey, appName, { errorTracking })` | Configure JS error tracking; pass `errorTracking: false` to disable (only if developer requests) |
+| `trackError({message, ...})` | Manually report an error (standalone import) |
+| `tracker.trackError({message, ...})` | Manually report an error (tracker instance) |
+| `ConvivaErrorBoundary` | React component that captures render-phase errors |
+| `errorTracker.addAttribute(key, value)` | Attach a custom attribute to all subsequent errors |
+| `errorTracker.removeAttribute(key)` | Remove a previously added error attribute |
+| `errorTracker.setEnabled(bool)` | Toggle error capture at runtime |
+| `errorTracker.setRateLimitingEnabled(bool)` | Toggle error rate limiting at runtime |
 | `removeTracker(namespace)` | Remove a tracker |
 | `removeAllTrackers()` | Remove all trackers |
 | `cleanup()` | Cleanup |
@@ -508,6 +516,71 @@ If the developer mentions opening web content outside `react-native-webview`, au
 
 ---
 
+## 16a. Error Tracking (Optional)
+
+JS error tracking is **on by default** and requires **no code**. Once `createTracker(...)` runs (Section 10), the SDK automatically captures uncaught JS errors, unhandled promise rejections, and native fatal crashes, each tagged with the current session ID and user ID. **Automatic capture is already active — do not add, import, or configure anything to enable it.**
+
+Everything in this section is **optional** and must be added **only when the developer asks for it in Step 1**. If you do nothing, automatic capture still works.
+
+---
+
+**Step 1 — Inform the developer and ask (required):**
+
+You must surface the optional controls — the developer cannot request what they have not been shown. Ask verbatim:
+
+> "Conviva automatically captures JavaScript errors (uncaught errors and unhandled promise rejections) and native crashes as soon as the tracker initializes — this is already on and needs no code. Optionally, I can also:
+> 1. **Disable** error tracking entirely.
+> 2. **Tune** capture — rate limiting, suppress-in-dev, or a `beforeCapture` filter.
+> 3. Add **`ConvivaErrorBoundary`** around a screen or subtree to catch render-phase errors and show a fallback UI.
+> 4. Add **`trackError(...)`** calls so errors you already handle in `try/catch` are reported.
+> 5. Attach **custom attributes** to every captured error.
+>
+> Which of these (if any) would you like? Default: keep automatic capture as-is and add nothing."
+
+| Developer response | Action |
+|---|---|
+| No reply / "none" / "keep defaults" | Add nothing. Record in Section 18: "Error tracking: automatic capture active; no optional controls requested." Move to Section 17. |
+| Selects one or more options | Apply only the matching steps below. |
+
+If the developer chooses **Option 1 (Disable)**, do **not** also apply Steps 4–6: a disabled module does not send errors to Conviva, so `ConvivaErrorBoundary`, `trackError`, and attributes would have no effect. Point this out if the developer asks for both.
+
+---
+
+**Step 2 — Disable error tracking (Option 1):**
+
+Pass `errorTracking: false` as the third argument to `createTracker` in `src/conviva.ts` (or `src/conviva.js`). See **AGENTS-snippets.md § Error Tracking**. Read the third-argument merge rule in **Step 7** before editing.
+
+**Step 3 — Tune capture via config (Option 2):**
+
+Pass an `errorTracking` object as the third argument to `createTracker`. **Use only the keys in the "Allowed `errorTracking` config keys" table in AGENTS-snippets.md § Error Tracking — do not invent config keys.** Read the third-argument merge rule in **Step 7** before editing.
+
+**Step 4 — Capture render-phase errors with `ConvivaErrorBoundary` (Option 3):**
+
+Render-phase errors are not caught by automatic capture. Import `ConvivaErrorBoundary` and wrap **only** the screen/subtree the developer named. Use only the props in Section 13. See **AGENTS-snippets.md § Error Tracking** for the snippet.
+
+**Step 5 — Manual reporting with `trackError` (Option 4):**
+
+Use `trackError({ message, ... })` (standalone import) or `tracker.trackError({ message, ... })` inside the developer's `try/catch`. `message` is required; all other fields are optional. `trackError` is a standalone export and needs no `tracker` instance. See **AGENTS-snippets.md § Error Tracking**.
+
+**Step 6 — Custom attributes (Option 5):**
+
+Use `errorTracker.addAttribute(key, value)` / `errorTracker.removeAttribute(key)`. `errorTracker` is a standalone singleton export — do not call it on the `tracker` instance and do not null-check it. See **AGENTS-snippets.md § Error Tracking**.
+
+**Step 7 — Third-argument merge rule (when applying Step 2 or 3):**
+
+`createTracker` accepts **one** third-argument object. Adding `errorTracking` here is the developer-authorized exception to the "no third argument" rule in Sections 4 and 10. If `src/conviva.ts` / `src/conviva.js` already passes a third argument (for example `clidSyncConfig` from Section 16), **merge `errorTracking` into the same object** — do not add a second argument and do not overwrite the existing keys. See the merged example in **AGENTS-snippets.md § Error Tracking**.
+
+---
+
+**Rules:**
+- Use only the symbols in Section 13 and the config keys listed in AGENTS-snippets.md § Error Tracking. Do not invent error-tracking APIs or config keys.
+- Apply minimal, localized edits only — error-tracking config goes in `src/conviva.ts` / `src/conviva.js`; `ConvivaErrorBoundary` wraps only the requested subtree.
+- Never execute shell commands. File edits only.
+
+Record in Section 18: automatic capture active; the developer was asked (Step 1); and any optional controls applied (or "none requested").
+
+---
+
 ## 17. Build and Validation
 
 **Build verification:** Ask developer to run both Android and iOS debug builds. Share any error output and fix using only Section 13 allowed symbols.
@@ -540,6 +613,7 @@ Seed your task list from this table before writing any code. Every row must appe
 | Custom events and tags | One code snippet each (if requested) |
 | PageView tracking | Implemented (if requested) or skipped |
 | WebView CLID sync | One of: (a) skipped — `react-native-webview` not found; (b) skipped — version < 11; (c) skipped by developer; (d) enabled — domains via remote config only; (e) configured with domains [list] and `clidSyncConfig` added to `createTracker`; non-`react-native-webview` surfaces noted if raised by developer |
+| Error tracking | Automatic capture active (no code added) by default; developer asked which optional controls they want (Section 16a Step 1); note any controls applied on request — `errorTracking` config (tuned or `false`), `ConvivaErrorBoundary` wraps, `trackError` calls, `errorTracker` attributes; or "none requested" |
 | AGP compatibility check | Detected AGP version; if >= 9.0, confirm plugin >= 0.3.7; or skipped if no Android setup |
 | Build verification | Outcome for both Android and iOS |
 | Product validation | Ask developer to validate in Pulse App -> Activation Module -> Live Lens |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 
 # Changelog
 
+## 0.5.0 (24/Jun/2026)
+- Adds React Native JS error tracking: automatic capture of uncaught errors and unhandled promise rejections with zero code changes.
+- Adds `ConvivaErrorBoundary` to capture render-phase errors in the React component tree.
+- Adds the `trackError(...)` API for manual error reporting with optional custom attributes.
+- Configurable via both the `errorTracking` option on `createTracker` and remote config.
+- Using latest android(v1.5.0) and ios(v1.13.0) native packages.
+
 ## 0.4.0 (22/May/2025)
 - Adds automatic client ID synchronization to in-app WebViews for RN 0.68+ with react-native-webview v11+, enabling unified user identity across native and web surfaces without developer code changes.
 - Using latest android(v1.4.0) and ios(v1.12.0) native packages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 # Changelog
 
-## 0.5.0 (24/Jun/2026)
+## 0.5.0 (28/Jun/2026)
 - Adds React Native JS error tracking: automatic capture of uncaught errors and unhandled promise rejections with zero code changes.
 - Adds `ConvivaErrorBoundary` to capture render-phase errors in the React component tree.
 - Adds the `trackError(...)` API for manual error reporting with optional custom attributes.

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -5,6 +5,7 @@ Use the Conviva React Native App Analytics SDK to auto-collect events and track 
 **Table of Contents**
 - [Quick Start](#quick-start)
 - [More Features](#more-features)
+- [Error Tracking](#error-tracking)
 - [Auto-collected Events](#auto-collected-events)
 - [FAQ](#faq)
 
@@ -655,6 +656,140 @@ try {
 }
 ```
 
+### Error Tracking
+
+> Available from React Native SDK v0.5.0.
+
+The SDK captures JavaScript errors automatically once `createTracker(...)` runs — **no extra code is required**. The following are captured out of the box:
+
+- **Uncaught errors** thrown anywhere in your JS (via a chained global error handler).
+- **Unhandled promise rejections** (promises rejected with no `.catch()`).
+- **Native fatal crashes**, deduplicated against the JS error stream.
+
+Rate limiting is enabled by default to protect against error storms.
+
+Error tracking is **on by default**. To disable it entirely, pass `errorTracking: false` as the third argument to `createTracker`: or via conviva remote config
+
+```js
+import { createTracker } from '@convivainc/conviva-react-native-appanalytics';
+
+const tracker = createTracker('YOUR_CUSTOMER_KEY', 'YOUR_APP_NAME', {
+  errorTracking: false, // fully disable JS error capture
+});
+```
+
+#### Configuration Options
+
+Pass an `errorTracking` object to `createTracker` to customize capture. Every field is optional.
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | `boolean` | `true` | Master switch for the error tracking module. |
+| `captureGlobalErrors` | `boolean` | `true` | Capture uncaught errors via the global handler. |
+| `captureUnhandledRejections` | `boolean` | `true` | Capture unhandled promise rejections. |
+| `suppressInDev` | `boolean` | `false` | Skip capture while running in dev mode (`__DEV__`). |
+| `enableRateLimiting` | `boolean` | `true` | Drop events once the per-window limit is exceeded. |
+| `maxEventsPerWindow` | `number` | `20` | Max events captured per rate-limit window. |
+| `rateLimitWindowMs` | `number` | `1000` | Rate-limit window length, in milliseconds. |
+| `disconnectDurationMs` | `number` | `2000` | Cool-down after the limit is hit, in milliseconds. |
+| `promiseRejectionsAsHandled` | `boolean` | `false` | Report unhandled rejections as handled (`warning`) instead of unhandled (`error`). |
+| `bundleId` | `string` | — | JS bundle hash for symbolication of OTA-updated apps. |
+| `beforeCapture` | `(payload) => boolean \| void` | — | Hook to enrich or filter each event. Return `false` to drop it. |
+
+```js
+const tracker = createTracker('YOUR_CUSTOMER_KEY', 'YOUR_APP_NAME', {
+  errorTracking: {
+    suppressInDev: true,
+    maxEventsPerWindow: 10,
+    beforeCapture: (payload) => {
+      // Drop noisy errors, or attach extra context before dispatch.
+      if (payload.message.includes('Network request failed')) {
+        return false; // suppress this event
+      }
+    },
+  },
+});
+```
+
+#### Capture Render-phase Errors with `ConvivaErrorBoundary`
+
+Errors thrown during a component's render are not caught by the global handler. Wrap any part of your tree in `ConvivaErrorBoundary` to capture those errors and render a fallback UI(optional).
+
+```jsx
+import { ConvivaErrorBoundary } from '@convivainc/conviva-react-native-appanalytics';
+
+<ConvivaErrorBoundary
+  name="CheckoutScreen"
+  fallback={({ error, reset }) => (
+    <View>
+      <Text>Something went wrong: {String(error && error.message)}</Text>
+      <Button title="Try again" onPress={reset} />
+    </View>
+  )}
+>
+  <CheckoutScreen />
+</ConvivaErrorBoundary>
+```
+
+| Prop | Type | Description |
+|---|---|---|
+| `children` | `ReactNode` | The subtree to protect. |
+| `fallback` | `ReactNode` or `({ error, reset }) => ReactNode` | What to render after an error is caught. |
+| `name` | `string` | Human-readable label attached to the captured error. |
+| `resetKeys` | `unknown[]` | When any value changes, the boundary resets and re-renders `children`. |
+| `onError` | `(error, componentStack) => void` | Optional callback invoked when an error is caught. Must not throw. |
+
+#### Report Errors Manually with `trackError`
+
+Use `trackError` inside a `try/catch` to report errors you handle yourself. `message` is required; all other fields are optional.
+
+```js
+import { trackError } from '@convivainc/conviva-react-native-appanalytics';
+
+try {
+  await riskyOperation();
+} catch (error) {
+  try {
+    await trackError({
+      message: error.message,
+      errorType: error.name,
+      stackTrace: error.stack,
+      isFatal: false,
+      isHandled: true,
+      attributes: { feature: 'checkout', step: 'payment' },
+    });
+  } catch (e) {
+    console.error(e);
+  }
+}
+```
+
+`trackError` is also available on the tracker instance as `tracker.trackError({ ... })`.
+
+#### Attach Custom Attributes to Every Error
+
+Use the `errorTracker` singleton to attach attributes that should appear on all subsequently captured errors (for example, app build or environment). Attributes persist until removed.
+
+```js
+import { errorTracker } from '@convivainc/conviva-react-native-appanalytics';
+
+try {
+  errorTracker.addAttribute('appBuild', '2026.6.1');
+  errorTracker.addAttribute('environment', 'production');
+  // Remove when no longer relevant:
+  errorTracker.removeAttribute('environment');
+} catch (error) {
+  console.error(error);
+}
+```
+
+`errorTracker` also exposes `setEnabled(boolean)` to toggle capture at runtime and `setRateLimitingEnabled(boolean)` to toggle rate limiting.
+
+#### Symbolication
+
+Minified, production stack traces are symbolicated automatically by Conviva's backend — no source-map upload step is required in your build.
+Note: For apps that ship JS via OTA updates, supply a `bundleId` in the `errorTracking` config so the backend can match the running bundle to its source maps.
+
 ---
 
 ## Auto-collected Events
@@ -665,7 +800,7 @@ Conviva automatically collects a rich set of app performance metrics after compl
 |---|---|---|
 | `network_request` | After receiving a network request response | Android: requires android-plugin; iOS: auto-collected |
 | `screen_view` | When a screen is interacted with on first launch or relaunch | Native sensors + Conviva instrumentation plugin + navigation container wrapping |
-| `application_error` | When an unhandled error occurs in the application | Auto-collected from native sensors |
+| `application_error` | When an unhandled error occurs in the application, including uncaught JavaScript errors and unhandled promise rejections | Auto-collected from native sensors; JS errors captured by the [Error Tracking](#error-tracking) module |
 | `button_click` | On button click callback | Native sensors + Conviva instrumentation babel plugin |
 | `application_background` | When the app moves to the background | Auto-collected from native sensors |
 | `application_foreground` | When the app moves to the foreground | Auto-collected from native sensors |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # conviva-react-native-appanalytics
 
-Use Conviva React Native App Analytics SDK to auto-collect events and track application-specific events and state changes. The React Native bridges are internally built on top of the [Android](https://github.com/Conviva/conviva-android-appanalytics) and [iOS](https://github.com/Conviva/conviva-ios-appanalytics) native sensors.
+Use Conviva React Native App Analytics SDK to auto-collect events, track application-specific events and state changes, and capture JS errors. The React Native bridges are internally built on top of the [Android](https://github.com/Conviva/conviva-android-appanalytics) and [iOS](https://github.com/Conviva/conviva-ios-appanalytics) native sensors.
 
 | | |
 |---|---|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convivainc/conviva-react-native-appanalytics",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Conviva React Native Application Analytics Library",
   "main": "conviva-react-native-appanalytics.js",
   "repository": {


### PR DESCRIPTION
- CHANGELOG: 0.5.0 entry (error tracking; android v1.5.0 / ios v1.13.0)
- DEVELOPER_GUIDE: Error Tracking section (config table, ConvivaErrorBoundary, trackError, attributes, backend symbolication) + TOC + application_error note
- AGENTS: new §16a Error Tracking (Optional) with required developer ask, third-arg merge rule, and contradiction guard; §13 allowed symbols; §18 checklist row; Workflow note that lettered subsections execute in sequence
- AGENTS-snippets: Error Tracking section with authoritative config-key table and a merged third-argument example
- README: mention JS error capture in the feature sentence
- package.json: 0.4.0 -> 0.5.0